### PR TITLE
Moved root definition outside of the location block

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -42,28 +42,26 @@ http {
     server {
         listen       8080;
         server_name  localhost;
+	root   /opt/app-root/src;
 
         #charset koi8-r;
 
         #access_log  /var/opt/rh/rh-nginx18/log/nginx/host.access.log  main;
 
         location / {
-            root   /opt/app-root/src;
 	    try_files $uri /index.html;
         }
 
         # redirect server error pages to the static page /40x.html
         #
-        error_page  404              /404.html;
+        error_page  404              /40x.html;
         location = /40x.html {
-            root   /opt/app-root/src;
         }
 
         # redirect server error pages to the static page /50x.html
         #
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {
-            root   /opt/app-root/src;
         }
 
         # Load modular configuration files 

--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -42,7 +42,7 @@ http {
     server {
         listen       8080;
         server_name  localhost;
-	root   /opt/app-root/src;
+        root   /opt/app-root/src;
 
         #charset koi8-r;
 
@@ -52,7 +52,7 @@ http {
         include /opt/app-root/etc/nginx.defaultserver.d/*.conf;
 
         location / {
-	    try_files $uri /index.html;
+            try_files $uri /index.html;
         }
 
         # redirect server error pages to the static page /40x.html


### PR DESCRIPTION
Per best practice described by:

https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#root-inside-location-block